### PR TITLE
Create camera_info_manager for each left and right

### DIFF
--- a/src/side_by_side_stereo_node.cpp
+++ b/src/side_by_side_stereo_node.cpp
@@ -59,11 +59,6 @@ image_transport::Publisher leftImagePublisher, rightImagePublisher;
 ros::Publisher leftCameraInfoPublisher, rightCameraInfoPublisher;
 sensor_msgs::CameraInfo leftCameraInfoMsg, rightCameraInfoMsg;
 
-// Camera info managers.
-camera_info_manager::CameraInfoManager *left_cinfo_;
-camera_info_manager::CameraInfoManager *right_cinfo_;
-
-
 // Image capture callback.
 void imageCallback(const sensor_msgs::ImageConstPtr& msg)
 {
@@ -137,61 +132,57 @@ int main(int argc, char** argv)
 {
     ros::init(argc, argv, "sxs_stereo");
     ros::NodeHandle nh("~");
-    ros::NodeHandle nh_left(nh, "left");
-    ros::NodeHandle nh_right(nh, "right");
-
     image_transport::ImageTransport it(nh);
 
     // load the camera info
     nh.param("left_camera_info_url", leftCameraInfoURL, std::string(""));
     ROS_INFO("left_camera_info_url=%s\n", leftCameraInfoURL.c_str());
+    nh.param("left_frame", leftFrame, std::string(""));
     nh.param("right_camera_info_url", rightCameraInfoURL, std::string(""));
     ROS_INFO("right_camera_info_url=%s\n", rightCameraInfoURL.c_str());
-
-    nh.param("left_frame", leftFrame, std::string(""));
     nh.param("right_frame", rightFrame, std::string(""));
-
-    // Allocate and initialize camera info managers.
-    left_cinfo_ = new camera_info_manager::CameraInfoManager(nh_left);
-    right_cinfo_ = new camera_info_manager::CameraInfoManager(nh_right);
-    left_cinfo_->loadCameraInfo(leftCameraInfoURL);
-    right_cinfo_->loadCameraInfo(rightCameraInfoURL);
-
-    // Pre-fill camera_info messages.
-    leftCameraInfoMsg = left_cinfo_->getCameraInfo();
-    rightCameraInfoMsg = right_cinfo_->getCameraInfo();
 
     // Load node settings.
     std::string inputImageTopic, leftOutputImageTopic, rightOutputImageTopic,
-        leftCameraInfoTopic, rightCameraInfoTopic;
+        leftCameraInfoTopic, rightCameraInfoTopic, leftCameraInfoManager, rightCameraInfoManager;
     nh.param("input_image_topic", inputImageTopic, 
         std::string("input_image_topic_not_set"));
     ROS_INFO("input topic to stereo splitter=%s\n", inputImageTopic.c_str());
     nh.param("left_output_image_topic", leftOutputImageTopic,
-        std::string("/sxs_stereo/left/image_raw"));
+        std::string("left/image_raw"));
     nh.param("right_output_image_topic", rightOutputImageTopic,
-        std::string("/sxs_stereo/right/image_raw"));
+        std::string("right/image_raw"));
     nh.param("left_camera_info_topic", leftCameraInfoTopic,
-        std::string("/sxs_stereo/left/camera_info"));
+        std::string("left/camera_info"));
     nh.param("right_camera_info_topic", rightCameraInfoTopic,
-        std::string("/sxs_stereo/right/camera_info"));
+        std::string("right/camera_info"));
+    nh.param("left_camera_info_manager_ns", leftCameraInfoManager, std::string("~/left"));
+    nh.param("right_camera_info_manager_ns", rightCameraInfoManager, std::string("~/right"));
     nh.param("output_width", outputWidth, 0);  // 0 -> use 1/2 input width.
     nh.param("output_height", outputHeight, 0);  // 0 -> use input height.
 
-
     // Register publishers and subscriber.
     imageSub = nh.subscribe(inputImageTopic.c_str(), 2, &imageCallback);
-    leftImagePublisher = it.advertise(leftOutputImageTopic.c_str(), 1);
-    rightImagePublisher = it.advertise(rightOutputImageTopic.c_str(), 1);
-    leftCameraInfoPublisher = nh_left.advertise<sensor_msgs::CameraInfo>
-        (leftCameraInfoTopic.c_str(), 1, true);
-    rightCameraInfoPublisher = nh_right.advertise<sensor_msgs::CameraInfo>
-        (rightCameraInfoTopic.c_str(), 1, true);
+    leftImagePublisher = it.advertise(leftOutputImageTopic.c_str(), 5);
+    rightImagePublisher = it.advertise(rightOutputImageTopic.c_str(), 5);
+    leftCameraInfoPublisher = nh.advertise<sensor_msgs::CameraInfo>
+        (leftCameraInfoTopic.c_str(), 5);
+    rightCameraInfoPublisher = nh.advertise<sensor_msgs::CameraInfo>
+        (rightCameraInfoTopic.c_str(), 5);
+
+    // Camera info managers.
+    ros::NodeHandle nh_left(leftCameraInfoManager);
+    ros::NodeHandle nh_right(rightCameraInfoManager);
+    // Allocate and initialize camera info managers.
+    camera_info_manager::CameraInfoManager left_cinfo_(nh_left,"camera",leftCameraInfoURL);
+    camera_info_manager::CameraInfoManager right_cinfo_(nh_right,"camera",rightCameraInfoURL);
+    left_cinfo_.loadCameraInfo(leftCameraInfoURL);
+    right_cinfo_.loadCameraInfo(rightCameraInfoURL);
+
+    // Pre-fill camera_info messages.
+    leftCameraInfoMsg = left_cinfo_.getCameraInfo();
+    rightCameraInfoMsg = right_cinfo_.getCameraInfo();
 
     // Run node until cancelled.
     ros::spin();
-
-    // De-allocate CameraInfoManagers.
-    left_cinfo_ -> ~CameraInfoManager();
-    right_cinfo_ -> ~CameraInfoManager();
 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
camera_info_maangerが左右のカメラで同じ名前になっていたためset_camera_infoできなかった問題を修正
camera_info_maangerは名前空間を指定する方法がないらしく、node handlerの名前空間を左右で分ける必要があるらしい
[How to configure CameraInfoManager set_camera_info service name?](https://answers.ros.org/question/318068/how-to-configure-camerainfomanager-set_camera_info-service-name/)

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #1
- fix #2
